### PR TITLE
Design homepage with hero, podcasts, burger collage, and more

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,142 @@
 "use client";
 
-import { useConvexAuth, useMutation, useQuery } from "convex/react";
-import { api } from "../convex/_generated/api";
 import Link from "next/link";
+import { useConvexAuth } from "convex/react";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { useRouter } from "next/navigation";
 
 export default function Home() {
   return (
     <>
-      <header className="sticky top-0 z-10 bg-background p-4 border-b-2 border-slate-200 dark:border-slate-800 flex flex-row justify-between items-center">
-        Convex + Next.js + Convex Auth
-        <SignOutButton />
+      <header className="sticky top-0 z-10 bg-background/80 backdrop-blur border-b border-slate-200 dark:border-slate-800">
+        <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+          <Link href="#home" className="font-semibold">
+            Greg, Michael &amp; Ching
+          </Link>
+          <nav className="hidden sm:flex items-center gap-6 text-sm">
+            <a href="#podcasts" className="hover:underline">
+              Podcasts
+            </a>
+            <a href="#burgers" className="hover:underline">
+              Burgers
+            </a>
+            <a href="#more" className="hover:underline">
+              ...and more
+            </a>
+          </nav>
+          <SignOutButton />
+        </div>
       </header>
-      <main className="p-8 flex flex-col gap-8">
-        <h1 className="text-4xl font-bold text-center">
-          Convex + Next.js + Convex Auth
-        </h1>
-        <Content />
+
+      <main id="home" className="mx-auto max-w-6xl px-4 py-12 sm:py-16 flex flex-col gap-16">
+        {/* Hero */}
+        <section className="grid grid-cols-1 md:grid-cols-2 items-center gap-8 md:gap-12">
+          <div className="flex flex-col gap-4">
+            <h1 className="text-4xl sm:text-5xl font-bold">
+              Three friends. One website.
+            </h1>
+            <p className="text-slate-600 dark:text-slate-300 text-lg">
+              We&apos;re Greg, Michael, and Ching — recording podcasts, eating
+              great burgers, and having fun building things together.
+            </p>
+            <div className="flex gap-3">
+              <a href="#podcasts" className="bg-foreground text-background px-4 py-2 rounded-md text-sm">
+                Explore Podcasts
+              </a>
+              <a href="#burgers" className="border border-slate-300 dark:border-slate-700 px-4 py-2 rounded-md text-sm">
+                See Burger Collage
+              </a>
+            </div>
+            <p className="text-xs text-slate-500 mt-2">
+              Hero image is a placeholder for now — replace /public/hero-placeholder.svg with your photo later.
+            </p>
+          </div>
+          <div className="w-full">
+            <img
+              src="/hero-placeholder.svg"
+              alt="Placeholder hero of Greg, Michael & Ching"
+              className="w-full h-72 sm:h-96 object-cover rounded-xl shadow"
+            />
+          </div>
+        </section>
+
+        {/* Podcasts */}
+        <section id="podcasts" className="flex flex-col gap-6">
+          <h2 className="text-3xl font-semibold">Our Podcasts</h2>
+          <p className="text-slate-600 dark:text-slate-300">
+            A few of the conversations we&apos;ve recorded together.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[
+              {
+                title: "Episode 1 — How We Met",
+                desc: "Origin stories, early projects, and what keeps us collaborating.",
+              },
+              {
+                title: "Episode 2 — Burger Philosophy",
+                desc: "From smash to stacked — the debates that shaped our tastings.",
+              },
+              {
+                title: "Episode 3 — Building in Public",
+                desc: "Sharing work, lessons learned, and the joy of shipping.",
+              },
+            ].map((p, i) => (
+              <article
+                key={i}
+                className="rounded-lg border border-slate-200 dark:border-slate-800 p-5 bg-white/60 dark:bg-black/20"
+              >
+                <h3 className="font-medium">{p.title}</h3>
+                <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">
+                  {p.desc}
+                </p>
+                <div className="mt-4 flex items-center gap-3">
+                  <button className="text-sm px-3 py-1.5 rounded-md bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900">
+                    Listen
+                  </button>
+                  <button className="text-sm px-3 py-1.5 rounded-md border border-slate-300 dark:border-slate-700">
+                    Details
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        {/* Burgers collage */}
+        <section id="burgers" className="flex flex-col gap-6">
+          <h2 className="text-3xl font-semibold">Burger Collage</h2>
+          <p className="text-slate-600 dark:text-slate-300">
+            A tasty grid of our burger outings. Replace placeholders with your photos.
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <div key={i} className="aspect-[4/3] overflow-hidden rounded-md">
+                <img
+                  src="/burger-placeholder.svg"
+                  alt={`Burger ${i + 1}`}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* And more */}
+        <section id="more" className="flex flex-col gap-4 rounded-xl border border-slate-200 dark:border-slate-800 p-6">
+          <h2 className="text-2xl font-semibold">...and more</h2>
+          <p className="text-slate-600 dark:text-slate-300">
+            This site is just getting started. Want to add photo galleries, episode pages,
+            maps of burger spots, or anything else? Let&apos;s build it together.
+          </p>
+          <p className="text-slate-600 dark:text-slate-300">
+            Open an issue with ideas or a pull request with improvements. We&apos;re excited to collaborate!
+          </p>
+        </section>
       </main>
+
+      <footer className="border-t border-slate-200 dark:border-slate-800 py-6 text-center text-sm text-slate-600 dark:text-slate-400">
+        © {new Date().getFullYear()} Greg · Michael · Ching
+      </footer>
     </>
   );
 }
@@ -27,133 +145,18 @@ function SignOutButton() {
   const { isAuthenticated } = useConvexAuth();
   const { signOut } = useAuthActions();
   const router = useRouter();
+  if (!isAuthenticated) return null;
   return (
-    <>
-      {isAuthenticated && (
-        <button
-          className="bg-slate-200 dark:bg-slate-800 text-foreground rounded-md px-2 py-1"
-          onClick={() =>
-            void signOut().then(() => {
-              router.push("/signin");
-            })
-          }
-        >
-          Sign out
-        </button>
-      )}
-    </>
+    <button
+      className="bg-slate-200 dark:bg-slate-800 text-foreground rounded-md px-2 py-1 text-sm"
+      onClick={() =>
+        void signOut().then(() => {
+          router.push("/signin");
+        })
+      }
+    >
+      Sign out
+    </button>
   );
 }
 
-function Content() {
-  const { viewer, numbers } =
-    useQuery(api.myFunctions.listNumbers, {
-      count: 10,
-    }) ?? {};
-  const addNumber = useMutation(api.myFunctions.addNumber);
-
-  if (viewer === undefined || numbers === undefined) {
-    return (
-      <div className="mx-auto">
-        <p>loading... (consider a loading skeleton)</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-8 max-w-lg mx-auto">
-      <p>Welcome {viewer ?? "Anonymous"}!</p>
-      <p>
-        Click the button below and open this page in another window - this data
-        is persisted in the Convex cloud database!
-      </p>
-      <p>
-        <button
-          className="bg-foreground text-background text-sm px-4 py-2 rounded-md"
-          onClick={() => {
-            void addNumber({ value: Math.floor(Math.random() * 10) });
-          }}
-        >
-          Add a random number
-        </button>
-      </p>
-      <p>
-        Numbers:{" "}
-        {numbers?.length === 0
-          ? "Click the button!"
-          : (numbers?.join(", ") ?? "...")}
-      </p>
-      <p>
-        Edit{" "}
-        <code className="text-sm font-bold font-mono bg-slate-200 dark:bg-slate-800 px-1 py-0.5 rounded-md">
-          convex/myFunctions.ts
-        </code>{" "}
-        to change your backend
-      </p>
-      <p>
-        Edit{" "}
-        <code className="text-sm font-bold font-mono bg-slate-200 dark:bg-slate-800 px-1 py-0.5 rounded-md">
-          app/page.tsx
-        </code>{" "}
-        to change your frontend
-      </p>
-      <p>
-        See the{" "}
-        <Link href="/server" className="underline hover:no-underline">
-          /server route
-        </Link>{" "}
-        for an example of loading data in a server component
-      </p>
-      <div className="flex flex-col">
-        <p className="text-lg font-bold">Useful resources:</p>
-        <div className="flex gap-2">
-          <div className="flex flex-col gap-2 w-1/2">
-            <ResourceCard
-              title="Convex docs"
-              description="Read comprehensive documentation for all Convex features."
-              href="https://docs.convex.dev/home"
-            />
-            <ResourceCard
-              title="Stack articles"
-              description="Learn about best practices, use cases, and more from a growing
-            collection of articles, videos, and walkthroughs."
-              href="https://www.typescriptlang.org/docs/handbook/2/basic-types.html"
-            />
-          </div>
-          <div className="flex flex-col gap-2 w-1/2">
-            <ResourceCard
-              title="Templates"
-              description="Browse our collection of templates to get started quickly."
-              href="https://www.convex.dev/templates"
-            />
-            <ResourceCard
-              title="Discord"
-              description="Join our developer community to ask questions, trade tips & tricks,
-            and show off your projects."
-              href="https://www.convex.dev/community"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ResourceCard({
-  title,
-  description,
-  href,
-}: {
-  title: string;
-  description: string;
-  href: string;
-}) {
-  return (
-    <div className="flex flex-col gap-2 bg-slate-200 dark:bg-slate-800 p-4 rounded-md h-28 overflow-auto">
-      <a href={href} className="text-sm underline hover:no-underline">
-        {title}
-      </a>
-      <p className="text-xs">{description}</p>
-    </div>
-  );
-}

--- a/public/burger-placeholder.svg
+++ b/public/burger-placeholder.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-label="Burger placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fff7ed"/>
+      <stop offset="100%" stop-color="#fef3c7"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="url(#bg)"/>
+  <text x="200" y="160" font-size="64" text-anchor="middle">🍔</text>
+</svg>
+

--- a/public/hero-placeholder.svg
+++ b/public/hero-placeholder.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="600" viewBox="0 0 1600 600" role="img" aria-label="Hero placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#dbeafe"/>
+      <stop offset="100%" stop-color="#fce7f3"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="600" fill="url(#g)"/>
+  <g fill="#0f172a" opacity="0.7">
+    <circle cx="200" cy="120" r="6"/>
+    <circle cx="1480" cy="520" r="6"/>
+    <circle cx="1280" cy="160" r="6"/>
+    <circle cx="360" cy="500" r="6"/>
+  </g>
+  <g font-family="system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, 'Helvetica Neue', Arial" text-anchor="middle">
+    <text x="800" y="270" font-size="56" fill="#0f172a" opacity="0.85">Photo of Greg, Michael &amp; Ching</text>
+    <text x="800" y="330" font-size="28" fill="#334155" opacity="0.85">(Placeholder — upload your hero image to /public/hero.jpg later)</text>
+  </g>
+</svg>
+


### PR DESCRIPTION
Summary
- Implemented a fresh homepage for Greg, Michael, and Ching.
- Added sections per request: Hero, Podcasts, Burger Collage, and “...and more”.
- Kept existing auth integration: a Sign out button still appears when authenticated.

Details
1) Hero section
- Big welcoming headline, short intro, and primary/secondary calls-to-action.
- Uses a local placeholder image at public/hero-placeholder.svg.
- To replace with your real photo later, simply add your image to public (e.g. public/hero.jpg) and update the src in app/page.tsx, or overwrite hero-placeholder.svg.

2) Podcasts section
- A responsive grid of episode cards with placeholder titles/descriptions and action buttons (Listen / Details). Replace with real data or wire up actions when ready.

3) Burger collage
- A responsive image grid that showcases burger outings.
- Uses a lightweight placeholder image at public/burger-placeholder.svg repeated across the grid. Swap these with real photos when available.

4) “...and more” section
- A short call-to-action inviting further collaboration and ideas.

Implementation notes
- Updated app/page.tsx to remove the previous Convex demo content and replace it with the new homepage layout while keeping the SignOutButton.
- Added two SVG placeholders under /public: hero-placeholder.svg and burger-placeholder.svg.
- Styling is done with the existing Tailwind setup and follows the repo’s conventions.

How to customize
- Hero image: replace public/hero-placeholder.svg with a real photo and keep the same file name (no code changes), or update the src in app/page.tsx.
- Podcast cards: edit the array inside the Podcasts section for real episode titles/descriptions and hook up buttons as needed.
- Burger collage: replace the placeholder image src with your real burger photos or map over real image URLs.

Notes about linting
- Code follows the Next.js + ESLint defaults in this repo. The environment here had disk space limits during dependency installation, so I could not run npm/pnpm to execute next lint locally, but the code avoids unused imports and adheres to the established patterns. If CI runs linting, it should pass. Please let me know if you prefer additional adjustments.

Closes #1