### PR TITLE
Show images from S3 on homepage (hero, burgers, outings) and extend list API with prefix support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,39 @@
 import type { NextConfig } from "next";
 
+function remotePatternsFromEnv(): NextConfig["images"] | undefined {
+  const base = process.env.S3_PUBLIC_BASE_URL;
+  if (base) {
+    try {
+      const u = new URL(base);
+      return {
+        remotePatterns: [
+          {
+            protocol: u.protocol.replace(":", "") as "http" | "https",
+            hostname: u.hostname,
+            port: "",
+            pathname: `${u.pathname.replace(/\/$/, "")}/**`,
+          },
+        ],
+      };
+    } catch {
+      // fall through to broad amazonaws pattern
+    }
+  }
+  return {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.amazonaws.com",
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  };
+}
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: remotePatternsFromEnv(),
 };
 
 export default nextConfig;
+


### PR DESCRIPTION
Summary
- Load hero image from s3://<bucket>/public/hero.jpeg if present, with graceful fallback to local placeholder
- Add Outings section and render both Burgers and Outings galleries directly from S3
- Extend /api/s3/list endpoint to accept a ?prefix= query parameter so any S3 folder (e.g. public/burgers/, public/outings/, public/hero.jpeg) can be listed
- Configure next/image to allow remote S3/CDN images via S3_PUBLIC_BASE_URL or fallback to *.amazonaws.com

Details
1) API: /api/s3/list
- Previously only listed a single, env-configured uploads prefix.
- Now supports a prefix query parameter with basic sanitization (no absolute paths or ..). Defaults to S3_UPLOAD_PREFIX for backwards compatibility.
- Response now includes the prefix used for clarity.

2) Homepage (app/page.tsx)
- New hook useS3Images(prefix) to fetch images for a given S3 prefix via the updated API.
- Hero image now attempts to load public/hero.jpeg from S3; shows /hero-placeholder.svg if not found.
- Created reusable GallerySection that renders a responsive grid from a given prefix.
- Burgers section now pulls images from public/burgers/ (falls back to placeholders when empty).
- Added new Outings section that pulls images from public/outings/.
- Navigation updated to include Outings.

3) next/image configuration (next.config.ts)
- If S3_PUBLIC_BASE_URL is provided, its hostname and path are allowed for Next Image remote images.
- Otherwise, fallback allows https://*.amazonaws.com/** so regional S3 endpoints work out of the box.

How it works with your bucket structure
- Hero: s3://podcasternation/public/hero.jpeg
- Burgers: s3://podcasternation/public/burgers/*
- Outings: s3://podcasternation/public/outings/*
The page will automatically show whatever images are present in these prefixes now and in the future.

Notes
- No changes were made to the upload flow; uploads still go to the uploads/ prefix. This PR focuses on displaying your existing public images. If you want uploads to target specific folders (e.g., public/burgers/), we can extend the presign endpoint similarly to accept a target prefix.
- Ensure that S3_PUBLIC_BASE_URL, AWS_REGION, and S3_BUCKET_NAME are configured in your environment for the API and image URLs. If S3_PUBLIC_BASE_URL is set to a CDN origin, images will be served from there.


Closes #6