### PR TITLE
Add burger favicon and update page to use it

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" aria-hidden="true" role="img">
+  <rect width="64" height="64" fill="none"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="52">🍔</text>
+</svg>
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,9 +16,6 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Podcasternation",
   description: "Podcasternation: podcasts, burgers, and more",
-  icons: {
-    icon: "/burger-placeholder.svg",
-  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Summary
- Added a burger favicon as an SVG at app/icon.svg (uses the 🍔 emoji).
- Updated Next.js metadata by removing the old custom icons entry so Next.js automatically serves the favicon from app/icon.svg for all routes.

Why
- Implements the requested burger favicon and ensures the page uses it.
- Using app/icon.svg is the idiomatic way in Next.js App Router; it avoids manual <link rel="icon"> management and keeps things consistent.

Notes
- No other functional changes. Linting passes via `pnpm run lint`.
- If you still want to keep a custom path, we could alternatively point Metadata.icons back to a public asset, but the current approach is simpler and recommended by Next.js.

Closes #13