### PR TITLE
Add reusable upload button tile to gallery lists (burgers and outings)

### DIFF
--- a/components/GallerySection.tsx
+++ b/components/GallerySection.tsx
@@ -1,5 +1,6 @@
 import useS3Images from "@/lib/hooks/useS3Images";
 import Image from "next/image";
+import UploadTile from "./UploadTile";
 
 export function GallerySection({
   id,
@@ -16,7 +17,7 @@ export function GallerySection({
   emptyPlaceholderCount?: number;
   emptyPlaceholderSrc?: string;
 }) {
-  const { images, loading } = useS3Images(prefix);
+  const { images, loading, reload } = useS3Images(prefix);
   const hasImages = images.length > 0;
 
   return (
@@ -60,7 +61,10 @@ export function GallerySection({
         {!hasImages && !emptyPlaceholderSrc && !loading && (
           <p className="text-sm text-slate-500">No images yet.</p>
         )}
+        {/* Reusable upload tile at the end */}
+        <UploadTile prefix={prefix} onUploaded={() => reload()} />
       </div>
     </section>
   );
 }
+

--- a/components/UploadTile.tsx
+++ b/components/UploadTile.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+export type UploadTileStatus = "idle" | "uploading" | "success" | "error";
+
+export default function UploadTile({
+  prefix,
+  onUploaded,
+  className,
+  label = "Add photo",
+}: {
+  prefix: string;
+  onUploaded?: (_info: { key: string; publicUrl: string }) => void;
+  className?: string;
+  label?: string;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [status, setStatus] = useState<UploadTileStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFileSelected(file: File) {
+    setStatus("uploading");
+    setError(null);
+    try {
+      const presignRes = await fetch("/api/s3/presign", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contentType: file.type, filename: file.name, prefix }),
+      });
+      const presigned = await presignRes.json();
+      if (!presignRes.ok) throw new Error(presigned?.error ?? "Failed to get upload URL");
+
+      const uploadRes = await fetch(presigned.url as string, {
+        method: "PUT",
+        headers: { "Content-Type": file.type },
+        body: file,
+      });
+      if (!uploadRes.ok) throw new Error("Upload failed");
+
+      setStatus("success");
+      onUploaded?.({ key: presigned.key as string, publicUrl: presigned.publicUrl as string });
+
+      // Reset status after a short delay
+      setTimeout(() => setStatus("idle"), 2000);
+    } catch (e) {
+      setStatus("error");
+      const msg = e instanceof Error ? e.message : "Something went wrong";
+      setError(msg);
+      // Clear error after a few seconds
+      setTimeout(() => {
+        setError(null);
+        setStatus("idle");
+      }, 4000);
+    } finally {
+      if (inputRef.current) inputRef.current.value = ""; // reset file input
+    }
+  }
+
+  return (
+    <div
+      className={[
+        "relative group aspect-[4/3] overflow-hidden rounded-md border border-dashed border-slate-300 dark:border-slate-700 flex items-center justify-center cursor-pointer select-none",
+        className ?? "",
+      ].join(" ")}
+      role="button"
+      tabIndex={0}
+      aria-label={label}
+      onClick={() => inputRef.current?.click()}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          inputRef.current?.click();
+        }
+      }}
+    >
+      {/* Plus icon */}
+      <div className="pointer-events-none flex flex-col items-center text-slate-500 dark:text-slate-400">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-10 h-10 opacity-80 group-hover:opacity-100"
+        >
+          <path d="M11 11V5a1 1 0 1 1 2 0v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H5a1 1 0 1 1 0-2h6z" />
+        </svg>
+        <span className="mt-1 text-xs">{status === "uploading" ? "Uploading…" : label}</span>
+      </div>
+
+      {/* Hidden file input */}
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) void handleFileSelected(f);
+        }}
+      />
+
+      {/* Status messages */}
+      {status === "success" && (
+        <div className="absolute bottom-1 left-1 right-1 text-center text-[11px] px-2 py-1 rounded bg-green-600/90 text-white">
+          Uploaded!
+        </div>
+      )}
+      {status === "error" && error && (
+        <div className="absolute bottom-1 left-1 right-1 text-center text-[11px] px-2 py-1 rounded bg-red-600/90 text-white">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/lib/hooks/useS3Images.ts
+++ b/lib/hooks/useS3Images.ts
@@ -4,10 +4,13 @@ type S3Image = { key: string; url: string };
 export default function useS3Images(prefix: string) {
   const [images, setImages] = useState<S3Image[]>([]);
   const [loading, setLoading] = useState(true);
+  const [version, setVersion] = useState(0);
+
   useEffect(() => {
     let cancelled = false;
     async function run() {
       try {
+        setLoading(true);
         const res = await fetch(
           `/api/s3/list?prefix=${encodeURIComponent(prefix)}`,
         );
@@ -23,6 +26,12 @@ export default function useS3Images(prefix: string) {
     return () => {
       cancelled = true;
     };
-  }, [prefix]);
-  return { images, loading };
+  }, [prefix, version]);
+
+  function reload() {
+    setVersion((v) => v + 1);
+  }
+
+  return { images, loading, reload } as const;
 }
+


### PR DESCRIPTION
Summary
- Implemented a reusable UploadTile component that renders a square, plus-sign button as the last item in gallery grids. Users can click/tap to upload an image.
- The tile shows inline status: Uploading…, success, and error messages.
- Integrated UploadTile into GallerySection so both Burgers and Outings sections now support direct uploads.

Details
- New components/UploadTile.tsx: client-side upload tile with accessible button behavior, hidden file input, and lightweight status notifications.
- Enhanced lib/hooks/useS3Images with a reload() function to allow galleries to refresh after successful uploads.
- Updated components/GallerySection.tsx to render the UploadTile as the final grid item and call reload() on successful upload.
- Extended app/api/s3/presign/route.ts to accept a custom prefix in the request body, with sanitization, so uploads go to the intended S3 subfolder (e.g., public/burgers/ or public/outings/).

Why
This addresses the request to add a reusable upload button as the last item in the Burgers and Outings lists, enabling users to add their own pictures and get feedback on upload success/errors.

Notes
- Linting passes with `pnpm run lint`.
- The presign endpoint now accepts an optional `prefix` string in POST body. It is sanitized and defaulted to S3_UPLOAD_PREFIX when not provided.
- No breaking changes for existing UploadsSection; it continues to work independently.


Closes #12