### PR TITLE
Use burger SVG as browser favicon

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" aria-hidden="true" role="img">
-  <rect width="64" height="64" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="52">🍔</text>
-</svg>
-

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,9 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Podcasternation",
   description: "Podcasternation: podcasts, burgers, and more",
+  icons: {
+    icon: "/burger-placeholder.svg",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Summary
- Set the site favicon to our burger SVG asset by adding the icons field to the Next.js app metadata.
- Removed the default app/icon.svg to avoid conflicting rel="icon" tags and ensure the burger icon is used consistently.

Details
- Next.js (app directory) automatically injects icons from either special files (app/icon.*) or metadata. By defining:
  icons: { icon: "/burger-placeholder.svg" }
  in app/layout.tsx, the framework outputs the correct <link rel="icon" ...> tag pointing at the SVG in /public.
- Deleting app/icon.svg prevents multiple rel="icon" tags being generated, so the browser reliably uses the burger SVG.

Why this approach
- Keeps the single source of truth for the favicon as our existing public/burger-placeholder.svg (the recently created burger icon).
- Minimal code change, no duplication of assets.

Verification
- Ran linting with `pnpm run lint` (Next.js ESLint) — no warnings or errors.
- On running the app, the page head contains <link rel="icon" href="/burger-placeholder.svg" /> and the tab displays the burger icon.

Notes
- If you prefer keeping app/icon.svg for convention, we can instead copy the burger SVG into app/icon.svg. I removed it to avoid ambiguity; happy to revert and rely solely on the special file if desired.

Closes #17