### PR TITLE
Refactor image upload to support folder selection and detailed errors

### DIFF
--- a/app/api/s3/presign/route.ts
+++ b/app/api/s3/presign/route.ts
@@ -8,7 +8,16 @@ export const runtime = "nodejs";
 const REGION = process.env.AWS_REGION;
 const BUCKET = process.env.S3_BUCKET_NAME;
 const PUBLIC_BASE = process.env.S3_PUBLIC_BASE_URL; // e.g. https://cdn.example.com or https://my-bucket.s3.us-east-1.amazonaws.com
-const PREFIX = process.env.S3_UPLOAD_PREFIX ?? "uploads/";
+const DEFAULT_PREFIX = process.env.S3_UPLOAD_PREFIX ?? "uploads/";
+
+const ALLOWED_FOLDERS = {
+  burgers: "public/burgers/",
+  outings: "public/outings/",
+} as const;
+
+type AllowedFolderKey = keyof typeof ALLOWED_FOLDERS;
+
+type ErrorWithCode = Error & { code?: string };
 
 function assertEnv() {
   const missing: string[] = [];
@@ -17,17 +26,19 @@ function assertEnv() {
   if (!process.env.AWS_ACCESS_KEY_ID) missing.push("AWS_ACCESS_KEY_ID");
   if (!process.env.AWS_SECRET_ACCESS_KEY) missing.push("AWS_SECRET_ACCESS_KEY");
   if (missing.length) {
-    throw new Error(`Missing required env vars: ${missing.join(", ")}`);
+    const err = new Error(`Missing required env vars: ${missing.join(", ")}`) as ErrorWithCode;
+    err.code = "MISSING_ENV";
+    throw err;
   }
 }
 
-function keyFrom(filename?: string) {
+function keyFrom({ filename, prefix }: { filename?: string; prefix: string }) {
   const safe = (filename ?? "file")
     .replace(/[^a-zA-Z0-9._-]/g, "-")
     .slice(0, 80);
   const id = randomUUID();
   const date = new Date().toISOString().replace(/[:.]/g, "");
-  return `${PREFIX}${date}-${id}-${safe}`;
+  return `${prefix}${date}-${id}-${safe}`;
 }
 
 function publicUrlForKey(key: string) {
@@ -40,18 +51,45 @@ export async function POST(req: NextRequest) {
   try {
     assertEnv();
 
-    const { contentType, filename } = (await req.json()) as {
+    const body = (await req.json()) as {
       contentType?: string;
       filename?: string;
+      folder?: AllowedFolderKey | string | null;
     };
+
+    const { contentType, filename } = body;
     if (!contentType) {
       return NextResponse.json(
-        { error: "contentType required" },
+        {
+          error: "contentType required",
+          code: "VALIDATION_ERROR",
+          hint: "Send the detected file MIME type as contentType (e.g. image/jpeg)",
+        },
         { status: 400 },
       );
     }
 
-    const key = keyFrom(filename);
+    let prefix = DEFAULT_PREFIX;
+    let resolvedFolder: AllowedFolderKey | null = null;
+
+    if (body.folder != null) {
+      const f = String(body.folder) as AllowedFolderKey;
+      if (f in ALLOWED_FOLDERS) {
+        prefix = ALLOWED_FOLDERS[f];
+        resolvedFolder = f;
+      } else {
+        return NextResponse.json(
+          {
+            error: `Unsupported folder: ${body.folder}`,
+            code: "UNSUPPORTED_FOLDER",
+            allowed: Object.keys(ALLOWED_FOLDERS),
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    const key = keyFrom({ filename, prefix });
 
     const client = new S3Client({ region: REGION });
     const command = new PutObjectCommand({
@@ -63,12 +101,28 @@ export async function POST(req: NextRequest) {
 
     const url = await getSignedUrl(client, command, { expiresIn: 60 * 5 });
 
-    return NextResponse.json({ url, key, publicUrl: publicUrlForKey(key) });
+    return NextResponse.json({
+      url,
+      key,
+      folder: resolvedFolder,
+      publicUrl: publicUrlForKey(key),
+    });
   } catch (e) {
     console.error("presign error", e);
+    const err = e as ErrorWithCode;
+    const message = err?.message ?? "Internal error";
+    const code = err?.code;
+
+    // Add safe, helpful hints for common cases
+    let hint: string | undefined;
+    if (code === "MISSING_ENV") {
+      hint = "Server is missing required AWS configuration. Ensure AWS credentials, region, and bucket name are set.";
+    }
+
     return NextResponse.json(
-      { error: e instanceof Error ? e.message : "Internal error" },
-      { status: 500 },
+      { error: message, code: code ?? "INTERNAL_ERROR", hint },
+      { status: code === "MISSING_ENV" ? 500 : 500 },
     );
   }
 }
+

--- a/components/UploadsSection.tsx
+++ b/components/UploadsSection.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { uploadImageToS3, type UploadFolder } from "@/lib/s3Upload";
+
+const folderToPrefix: Record<UploadFolder, string> = {
+  burgers: "public/burgers/",
+  outings: "public/outings/",
+};
 
 export default function UploadsSection() {
   const [images, setImages] = useState<Array<{ key: string; url: string }>>([]);
@@ -10,10 +16,16 @@ export default function UploadsSection() {
     "idle" | "uploading" | "error" | "success"
   >("idle");
   const [error, setError] = useState<string | null>(null);
+  const [details, setDetails] = useState<string | null>(null);
+  const [folder, setFolder] = useState<UploadFolder>("burgers");
+
+  const prefix = useMemo(() => folderToPrefix[folder], [folder]);
 
   async function fetchImages() {
     try {
-      const res = await fetch("/api/s3/list", { cache: "no-store" });
+      const res = await fetch(`/api/s3/list?prefix=${encodeURIComponent(prefix)}`, {
+        cache: "no-store",
+      });
       const data = await res.json();
       if (res.ok) setImages(data.images);
     } catch (e) {
@@ -23,28 +35,26 @@ export default function UploadsSection() {
 
   useEffect(() => {
     void fetchImages();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefix]);
 
   async function handleUpload() {
     if (!file) return;
     setStatus("uploading");
     setError(null);
+    setDetails(null);
     try {
-      const presignRes = await fetch("/api/s3/presign", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ contentType: file.type, filename: file.name }),
-      });
-      const { url } = await presignRes.json();
-      if (!presignRes.ok) throw new Error("Failed to get upload URL");
-
-      const uploadRes = await fetch(url, {
-        method: "PUT",
-        headers: { "Content-Type": file.type },
-        body: file,
-      });
-      if (!uploadRes.ok) throw new Error("Upload failed");
-
+      const res = await uploadImageToS3(file, folder);
+      if (!res.ok) {
+        setStatus("error");
+        setError(res.error);
+        const extra: string[] = [];
+        if (res.code) extra.push(`code: ${res.code}`);
+        if (res.status) extra.push(`status: ${res.status}`);
+        if (res.hint) extra.push(`hint: ${res.hint}`);
+        if (extra.length) setDetails(extra.join(" | "));
+        return;
+      }
       setStatus("success");
       setFile(null);
       await fetchImages();
@@ -58,10 +68,22 @@ export default function UploadsSection() {
     <section id="uploads" className="flex flex-col gap-6">
       <h2 className="text-3xl font-semibold">Your uploads (S3)</h2>
       <p className="text-slate-600 dark:text-slate-300">
-        Choose an image to upload directly to S3. We&apos;ll show the most
+        Choose an image and a destination folder to upload directly to S3. We&apos;ll show the most
         recent ones below.
       </p>
-      <div className="flex items-center gap-3">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+        <div className="flex items-center gap-2">
+          <label htmlFor="folder" className="text-sm">Folder:</label>
+          <select
+            id="folder"
+            value={folder}
+            onChange={(e) => setFolder(e.target.value as UploadFolder)}
+            className="text-sm border border-slate-300 dark:border-slate-700 rounded-md px-2 py-1 bg-transparent"
+          >
+            <option value="burgers">burgers</option>
+            <option value="outings">outings</option>
+          </select>
+        </div>
         <input
           type="file"
           accept="image/*"
@@ -73,9 +95,14 @@ export default function UploadsSection() {
           disabled={!file || status === "uploading"}
           className="text-sm px-3 py-1.5 rounded-md bg-foreground text-background disabled:opacity-50"
         >
-          {status === "uploading" ? "Uploading..." : "Upload to S3"}
+          {status === "uploading" ? "Uploading..." : `Upload to ${folder}`}
         </button>
-        {error && <span className="text-xs text-red-500">{error}</span>}
+        {error && (
+          <div className="text-xs text-red-500">
+            <span>{error}</span>
+            {details && <span className="block text-[10px] opacity-80 mt-0.5">{details}</span>}
+          </div>
+        )}
       </div>
 
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
@@ -94,13 +121,14 @@ export default function UploadsSection() {
           </div>
         ))}
         {images.length === 0 && (
-          <p className="text-sm text-slate-500">No uploads yet.</p>
+          <p className="text-sm text-slate-500">No uploads yet in {folder}.</p>
         )}
       </div>
       <p className="text-xs text-slate-500">
-        Note: Make sure your S3 bucket CORS allows PUT from this origin and
-        objects are publicly viewable or served via a CDN.
+        Note: Ensure your S3 bucket CORS allows PUT from this origin and objects are publicly
+        viewable or served via a CDN.
       </p>
     </section>
   );
 }
+

--- a/lib/s3Upload.ts
+++ b/lib/s3Upload.ts
@@ -1,0 +1,108 @@
+export type UploadFolder = "burgers" | "outings";
+
+export type UploadSuccess = {
+  ok: true;
+  key: string;
+  publicUrl: string;
+  folder: UploadFolder;
+};
+
+export type UploadFailure = {
+  ok: false;
+  stage: "presign" | "upload";
+  error: string;
+  code?: string;
+  status?: number;
+  hint?: string;
+  details?: unknown;
+};
+
+export async function uploadImageToS3(
+  file: File,
+  folder: UploadFolder,
+): Promise<UploadSuccess | UploadFailure> {
+  try {
+    const presignRes = await fetch("/api/s3/presign", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contentType: file.type || "application/octet-stream",
+        filename: file.name,
+        folder,
+      }),
+    });
+
+    let presignJson: unknown = null;
+    try {
+      presignJson = await presignRes.json();
+    } catch (_err) {
+      // swallow JSON parse error and report raw body later
+    }
+
+    if (!presignRes.ok) {
+      const data = presignJson as
+        | { error?: string; code?: string; hint?: string }
+        | null;
+      return {
+        ok: false,
+        stage: "presign",
+        error: (data && data.error) || `Failed to get upload URL (HTTP ${presignRes.status})`,
+        code: data?.code,
+        status: presignRes.status,
+        hint: data?.hint,
+        details: data,
+      };
+    }
+
+    const { url, publicUrl, key } = presignJson as {
+      url: string;
+      publicUrl: string;
+      key: string;
+    };
+
+    const uploadRes = await fetch(url, {
+      method: "PUT",
+      headers: { "Content-Type": file.type || "application/octet-stream" },
+      body: file,
+    });
+
+    if (!uploadRes.ok) {
+      // S3 often provides XML error responses; include status info for debugging
+      let bodyText: string | undefined;
+      try {
+        bodyText = await uploadRes.text();
+      } catch {
+        // ignore
+      }
+      return {
+        ok: false,
+        stage: "upload",
+        error: `S3 rejected the upload (HTTP ${uploadRes.status}).`,
+        status: uploadRes.status,
+        hint:
+          uploadRes.status === 403
+            ? "Check bucket CORS, signed URL expiration, and IAM permissions (s3:PutObject)."
+            : uploadRes.status === 400
+              ? "Content-Type mismatch or malformed request."
+              : undefined,
+        details: bodyText,
+      };
+    }
+
+    return { ok: true, key, publicUrl, folder };
+  } catch (e) {
+    // Network or unexpected errors
+    const msg =
+      e instanceof Error ? e.message : "Unexpected error during upload.";
+    const isNetwork = msg.toLowerCase().includes("network");
+    return {
+      ok: false,
+      stage: "upload",
+      error: msg,
+      hint: isNetwork
+        ? "Network error — possibly blocked by CORS or offline."
+        : undefined,
+    };
+  }
+}
+


### PR DESCRIPTION
Summary
- Implemented a dedicated, reusable upload function and refactored the upload flow to support uploading to specific folders (burgers and outings).
- Enhanced error handling to provide meaningful, non-sensitive details back to the frontend for easier debugging.

What changed
1) API: POST /api/s3/presign
- Added support for a folder parameter with a strict allowlist: "burgers" → public/burgers/ and "outings" → public/outings/.
- Keeps a safe default prefix when no folder is provided.
- Returns structured error responses { error, code, hint } for common failures (e.g., missing env vars, unsupported folder).
- Generates keys within the selected folder and returns a publicUrl for convenience.

2) New frontend utility: lib/s3Upload.ts
- export async function uploadImageToS3(file, folder)
- Handles presign request and PUT upload to S3 signed URL.
- Returns rich results with stage (presign|upload), status codes, optional error code, hint, and details for developer visibility on the frontend.

3) UI: components/UploadsSection.tsx
- Added a simple folder selector (burgers|outings).
- Upload now delegates to uploadImageToS3().
- Shows more informative error messages (including hint, status, and code when present).
- Image listing now reflects the selected folder via /api/s3/list?prefix=...

Why
- Prior uploads were tied to a single prefix and didn’t surface actionable errors.
- This refactor isolates upload logic in a reusable function and supports explicit folder destinations required by the issue.
- Frontend and developers get clearer, safe error messages (e.g., missing AWS config, CORS/permission hints) without exposing sensitive data.

Notes
- The API validates the folder to prevent unintended paths.
- The list endpoint already supports a prefix query and required no changes.
- ACL: "public-read" remains; if bucket policy differs, you can remove it or adjust accordingly.

How to use
- In UploadsSection, pick the target folder (burgers or outings), choose a file, and upload. The grid below shows recent images for that folder.

Linting/quality
- Ran repo’s lint task (pnpm run lint) — no warnings or errors.

If you’d like, we can add unit/integration tests for the presign API or further extend the utility to accept additional folders in the future.

Closes #16