### PR TITLE
Add reusable upload tile and integrate into Burgers/Outings galleries

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,6 +155,7 @@ export default function Home() {
           prefix="public/burgers/"
           emptyPlaceholderCount={12}
           emptyPlaceholderSrc="/burger-placeholder.svg"
+          uploadFolder="burgers"
         />
 
         {/* Outings collage from S3 */}
@@ -164,6 +165,7 @@ export default function Home() {
           description="A montage of our gatherings."
           prefix="public/outings/"
           emptyPlaceholderCount={0}
+          uploadFolder="outings"
         />
 
         {/* Movies - reviews with Greg's weighted opinion */}

--- a/components/GallerySection.tsx
+++ b/components/GallerySection.tsx
@@ -1,5 +1,7 @@
 import useS3Images from "@/lib/hooks/useS3Images";
 import Image from "next/image";
+import UploadTile from "./UploadTile";
+import type { UploadFolder } from "@/lib/s3Upload";
 
 export function GallerySection({
   id,
@@ -8,6 +10,7 @@ export function GallerySection({
   prefix,
   emptyPlaceholderCount = 0,
   emptyPlaceholderSrc,
+  uploadFolder,
 }: {
   id: string;
   title: string;
@@ -15,8 +18,9 @@ export function GallerySection({
   prefix: string;
   emptyPlaceholderCount?: number;
   emptyPlaceholderSrc?: string;
+  uploadFolder?: UploadFolder;
 }) {
-  const { images, loading } = useS3Images(prefix);
+  const { images, loading, refresh } = useS3Images(prefix);
   const hasImages = images.length > 0;
 
   return (
@@ -44,6 +48,13 @@ export function GallerySection({
               />
             </div>
           ))}
+        {uploadFolder && (
+          <UploadTile
+            folder={uploadFolder}
+            className=""
+            onUploaded={() => void refresh()}
+          />
+        )}
         {!hasImages &&
           emptyPlaceholderSrc &&
           Array.from({ length: emptyPlaceholderCount }).map((_, i) => (
@@ -64,3 +75,4 @@ export function GallerySection({
     </section>
   );
 }
+

--- a/components/UploadTile.tsx
+++ b/components/UploadTile.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { uploadImageToS3, type UploadFolder } from "@/lib/s3Upload";
+
+type Status = "idle" | "uploading" | "success" | "error";
+
+export default function UploadTile({
+  folder,
+  onUploaded,
+  className = "",
+}: {
+  folder: UploadFolder;
+  onUploaded?: (_: { key: string; publicUrl: string; folder: UploadFolder }) => void;
+  className?: string;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [details, setDetails] = useState<string | null>(null);
+
+  function pickFile() {
+    setError(null);
+    setDetails(null);
+    inputRef.current?.click();
+  }
+
+  async function onFileChange(file: File | null) {
+    if (!file) return;
+    setStatus("uploading");
+    setError(null);
+    setDetails(null);
+
+    const res = await uploadImageToS3(file, folder);
+    if (!res.ok) {
+      setStatus("error");
+      setError(res.error);
+      const extra: string[] = [];
+      if (res.code) extra.push(`code: ${res.code}`);
+      if (res.status) extra.push(`status: ${res.status}`);
+      if (res.hint) extra.push(`hint: ${res.hint}`);
+      if (extra.length) setDetails(extra.join(" | "));
+      return;
+    }
+
+    setStatus("success");
+    onUploaded?.({ key: res.key, publicUrl: res.publicUrl, folder: res.folder });
+    // reset success state after a short delay
+    setTimeout(() => setStatus("idle"), 1200);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={pickFile}
+      aria-label={`Upload photo to ${folder}`}
+      className={`aspect-[4/3] rounded-md border border-dashed border-slate-300 dark:border-slate-700 flex items-center justify-center text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-white/5 transition-colors ${
+        status === "error" ? "border-red-400 text-red-500" : ""
+      } ${className}`}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+      />
+      {status === "uploading" && (
+        <span className="text-sm animate-pulse">Uploading...</span>
+      )}
+      {status === "success" && (
+        <span className="text-sm text-green-600">Uploaded!</span>
+      )}
+      {status === "idle" && (
+        <div className="flex flex-col items-center gap-1 select-none">
+          <div className="w-9 h-9 rounded-md bg-slate-200 dark:bg-slate-700 flex items-center justify-center">
+            <span className="text-xl leading-none">+</span>
+          </div>
+          <span className="text-xs">Add photo</span>
+        </div>
+      )}
+      {status === "error" && (
+        <div className="flex flex-col items-center gap-1">
+          <span className="text-xs font-medium">Upload failed</span>
+          {error && <span className="text-[10px] opacity-80 text-red-500 text-center px-2">{error}</span>}
+          {details && (
+            <span className="text-[10px] opacity-60 text-red-500 text-center px-2">{details}</span>
+          )}
+          <span className="text-[10px] opacity-70">Tap to retry</span>
+        </div>
+      )}
+    </button>
+  );
+}
+


### PR DESCRIPTION
Summary
- Added a reusable UploadTile component that appears as a tile at the end of image grids and lets users upload a new photo via S3.
- Integrated the tile into the Burgers and Outings sections by extending GallerySection with an optional uploadFolder prop.
- The tile displays upload progress, success, and error states inline.
- On successful upload, the gallery auto-refreshes to show the new photo.

Details
- components/UploadTile.tsx: New client component providing a square tile UI with a plus sign. Manages statuses (idle, uploading, success, error) and triggers the S3 upload using the existing uploadImageToS3 helper. It also surfaces errors and helpful hints inline.
- lib/hooks/useS3Images.ts: Now returns a refresh() function and uses no-store fetch to reduce caching delays after uploads.
- components/GallerySection.tsx: Accepts optional uploadFolder ("burgers" | "outings"). If provided, renders the UploadTile as the last item in the grid and refreshes images after success.
- app/page.tsx: Enables upload tiles for the Burgers and Outings sections by passing uploadFolder.

Why this approach
- Keeps the upload tile reusable and focused so it can be easily added to other galleries in the future.
- Minimal changes to existing components; GallerySection remains generic and only opt-in adds upload functionality.
- Leverages existing API routes and s3Upload helper for a consistent upload flow.

Testing notes
- Linting and type checks pass (pnpm run lint and tsc --noEmit).
- To test manually, ensure AWS env vars and S3 CORS are configured, then:
  1. Open the homepage.
  2. Scroll to Burgers/Outings — a "+ Add photo" tile appears as the last grid item.
  3. Click the tile, pick an image, observe inline status updates.
  4. After success, the new photo should appear in the grid automatically.

Future enhancements
- Optionally debounce or throttle gallery refresh if batching uploads.
- Allow drag-and-drop onto the tile.
- Make the tile size/style configurable through props if needed.

Closes #12